### PR TITLE
Aktuellen StaPF-Paragraphen aus Wiki genommen

### DIFF
--- a/Satzung_der_ZaPF.tex
+++ b/Satzung_der_ZaPF.tex
@@ -45,27 +45,30 @@ stellt davon allen Mitglieds-fachschaften ein Exemplar zur Verfügung.
           Plenen regelt die Geschäftsordnung für Plenen der ZaPF.
     \item \textbf{Der Ständige Ausschuss der Physik-Fachschaften (StAPF)}\\
           Der Ständige Ausschuss der Physik-Fachschaften (StAPF) vertritt die
-          ZaPF in der Öffentlichkeit. Zu jeder im Sommersemester stattfindenden
-          ZaPF wird der StAPF neu gewählt. Sollten ein oder mehrere Posten im
-          StAPF vakant sein, muss im Abschlussplenum der Winter-ZaPF eine
-          Nachbesetzung durchgeführt werden. Die Nachbesetzung ist eine
-          Personenwahl wie zur Wahl des gesamten StAPF. Sollte es keine
-          Kandidaten für diese Posten geben, bleiben sie vakant. Der StAPF
-          besteht aus maximal fünf Physik-Studierenden von mindestens drei
-          verschiedenen Hochschulen. Er konferiert öffentlich mindestens
-          zweimal zwischen den ZaPFen.  Termin und Tagungsort (auf einer ZaPF,
-          öffentlicher Chatraum, etc.) sind rechtzeitig an geeigneter Stelle
-          bekannt zu machen. Der StAPF ist an die Weisungen des Plenums
-          gebunden, kann jedoch eigenverantwortlich handeln und muss seine
-          Beschlüsse dem ZaPF-Plenum gegenüber vertreten. Die Entscheidungen
-          innerhalb des StAPF müssen in diesen Fällen einstimmig fallen. Der
-          StAPF gibt Informationen umgehend an die Fachschaften weiter.  Auf
-          jeder ZaPF ist darüber hinaus ein Rechenschaftsbericht vorzulegen.
-          Der StAPF ist für die Archivierung und Veröffentlichung der
-          Ergebnisse der ZaPF verantwortlich, des Weiteren ist er Unterzeichner
-          der ZaPF-Veröffentlichungen.  Der StAPF wählt sich aus seiner Mitte
-          einen Sprecher. Sollte kein StAPF gewählt werden übernimmt das Plenum
-          der ZaPF die Aufgaben des StAPF.
+          ZaPF in der Öffentlichkeit. Der StAPF besteht aus fünf Physik-Studierenden
+          von mindestens drei verschiedenen Hochschulen, welche für jeweils ein
+          Jahr gewählt werden. Zu jeder im Sommersemester stattfindenden ZaPF
+          werden drei Mitglieder des StAPF neu gewählt. Zu jeder im Wintersemester
+          stattfindenden ZaPF werden zwei Mitglieder des StAPF neu gewählt.
+          Sollten ein oder mehrere Posten im StAPF vakant sein, muss im
+          Abschlussplenum der darauf folgenden ZaPF eine Nachbesetzung
+          durchgeführt werden. Die Nachbesetzung ist eine Personenwahl wie zur
+          Wahl des gesamten StAPF. Sollte es keine Kandidaten für diese Posten
+          geben, bleiben sie vakant. Der StAPF besteht aus maximal fünf
+          Physik-Studierenden von mindestens drei verschiedenen Hochschulen.
+          Er konferiert öffentlich mindestens zweimal zwischen den ZaPFen.
+          Termin und Tagungsort (auf einer ZaPF, öffentlicher Chatraum, etc.)
+          sind rechtzeitig an geeigneter Stelle bekannt zu machen. Der StAPF ist
+          an die Weisungen des Plenums gebunden, kann jedoch eigenverantwortlich
+          handeln und muss seine Beschlüsse dem ZaPF-Plenum gegenüber vertreten.
+          Die Entscheidungen innerhalb des StAPF müssen in diesen Fällen einstimmig
+          fallen. Der StAPF gibt Informationen umgehend an die Fachschaften weiter.
+          Auf jeder ZaPF ist darüber hinaus ein Rechenschaftsbericht vorzulegen.
+          Der StAPF ist für die Archivierung und Veröffentlichung der Ergebnisse
+          der ZaPF verantwortlich, des Weiteren ist er Unterzeichner der
+          ZaPF-Veröffentlichungen. Der StAPF wählt sich aus seiner Mitte einen
+          Sprecher. Sollte kein StAPF gewählt werden übernimmt das Plenum der
+          ZaPF die Aufgaben des StAPF.
   \end{enumerate}
 
 \section*{§ 7 Satzungsänderungen}


### PR DESCRIPTION
Dies ist die aktuelle Formulierung des Paragraphen zum StAPF aus dem [Wiki](https://vmp.ethz.ch/zapfwiki/index.php/Satzung_der_ZaPF).
