### PR TITLE
Modus der Abwahl gestrichen

### DIFF
--- a/satzung.rst
+++ b/satzung.rst
@@ -48,7 +48,7 @@ Personenwahlen entsprechend der Geschäftsordnung der ZaPF.
 
 Die Mitgliedschaft im StAPF, dem Kommunikationsgremium oder dem TOPF endet mit
 Ablauf der Amtszeit, Ableben des Amtsinhabers oder der Amtsinhaberin,
-Niederlegung des Amtes oder Abwahl Plenum.
+Niederlegung des Amtes oder Abwahl durch das Plenum.
 
 Bis zur Nachwahl bleibt ein unbesetztes Amt vakant. Bei der Nachwahl wird das
 Amt bis zum Ablauf der Restdauer der Amtszeit besetzt.

--- a/satzung.rst
+++ b/satzung.rst
@@ -48,9 +48,7 @@ Personenwahlen entsprechend der Geschäftsordnung der ZaPF.
 
 Die Mitgliedschaft im StAPF, dem Kommunikationsgremium oder dem TOPF endet mit
 Ablauf der Amtszeit, Ableben des Amtsinhabers oder der Amtsinhaberin,
-Niederlegung des Amtes oder Abwahl mit Zweidrittelmehrheit durch das Plenum. Der
-Antrag auf Abwahl ist bis 15:00 Uhr am Vortag bei der ausrichtenden Fachschaft
-anzukündigen.
+Niederlegung des Amtes oder Abwahl Plenum.
 
 Bis zur Nachwahl bleibt ein unbesetztes Amt vakant. Bei der Nachwahl wird das
 Amt bis zum Ablauf der Restdauer der Amtszeit besetzt.


### PR DESCRIPTION
Die Vestlegung des Modus der Abwahl sollte nicht in der Satzung, sondern in der
Geschäftsordnung festgelegt sein. Gemeinsam mit ZaPF/Geschaeftsordnung_ZaPF#22
würde dies geschehen.
