### PR TITLE
Definiere ein Jahr

### DIFF
--- a/satzung.rst
+++ b/satzung.rst
@@ -65,6 +65,13 @@ Sollten nach einer Wahl Posten unbesetzt sein, bleiben sie vakant.
 Falls mindestens zwei Drittel der Mitglieder eines Gremiums das Amt niederlegen,
 gelten auch die Ämter der übrigen Mitglieder dieses Gremiums als vakant.
 
+Für Amtszeiten sei ein Jahr definiert als die Zeit zwischen einer Sommer-ZaPF
+und der ihr nächsten nachfolgenden Sommer-ZaPF bzw. einer Winter-ZaPF und der
+ihr nächsten nachfolgenden Winter-ZaPF. Das Jahr beginnt mit dem Plenum in dem
+die Wahl für ein Organ stattfindet und endet mit dem Plenum in dem die Wahl zur
+Neubesetzung der entsprechenden Plätze des Organs stattfindet, spätestens jedoch
+mit dem Ende der Tagung.
+
 (a) Das ZaPF-Plenum
 ^^^^^^^^^^^^^^^^^^^
 

--- a/satzung.rst
+++ b/satzung.rst
@@ -68,9 +68,9 @@ gelten auch die Ämter der übrigen Mitglieder dieses Gremiums als vakant.
 Für Amtszeiten sei ein Jahr definiert als die Zeit zwischen einer Sommer-ZaPF
 und der ihr nächsten nachfolgenden Sommer-ZaPF bzw. einer Winter-ZaPF und der
 ihr nächsten nachfolgenden Winter-ZaPF. Das Jahr beginnt mit dem Plenum in dem
-die Wahl für ein Organ stattfindet und endet mit dem Plenum in dem die Wahl zur
-Neubesetzung der entsprechenden Plätze des Organs stattfindet, spätestens jedoch
-mit dem Ende der Tagung.
+die Wahl für ein Organ turnusmäßig stattfindet und endet mit dem Plenum in dem
+die Wahl zur Neubesetzung der entsprechenden Plätze des Organs turnusmäßig
+stattfindet, spätestens jedoch mit dem Ende der Tagung.
 
 (a) Das ZaPF-Plenum
 ^^^^^^^^^^^^^^^^^^^

--- a/satzung.rst
+++ b/satzung.rst
@@ -67,10 +67,12 @@ gelten auch die Ämter der übrigen Mitglieder dieses Gremiums als vakant.
 
 Für Amtszeiten sei ein Jahr definiert als die Zeit zwischen einer Sommer-ZaPF
 und der ihr nächsten nachfolgenden Sommer-ZaPF bzw. einer Winter-ZaPF und der
-ihr nächsten nachfolgenden Winter-ZaPF. Das Jahr beginnt mit dem Plenum in dem
-die Wahl für ein Organ turnusmäßig stattfindet und endet mit dem Plenum in dem
-die Wahl zur Neubesetzung der entsprechenden Plätze des Organs turnusmäßig
-stattfindet, spätestens jedoch mit dem Ende der Tagung.
+ihr nächsten nachfolgenden Winter-ZaPF.
+Das Jahr beginnt mit dem Ende des Plenums in dem die Wahl für ein Organ
+turnusmäßig stattfindet.
+Es endet mit dem Plenum, in dem die Wahl zur Neubesetzung der entsprechenden
+Plätze des Organs turnusmäßig stattfindet, spätestens jedoch mit dem Ende der
+Tagung.
 
 (a) Das ZaPF-Plenum
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Die Amtszeiten aller ZaPF-Organe ist ein Jahr, allerdings definieren wir nie was ein Jahr ist und zwischen zwei ZaPFen vergeht selten genau ein Jahr. Diese PR fügt eine solche Definition hinzu.