### PR TITLE
Erweitere die Antragsfrist für Satzungsänderungen

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -218,7 +218,7 @@ Die Amtszeit der hauptverantwortlichen Personen beträgt ein Jahr.
 Änderungen dieser Satzung benötigen eine Zweidrittelmehrheit, wobei Beschlussfähigkeit
 des Plenums vor der Abstimmung zwingend festzustellen ist.
 Satzungsänderungen sind nicht durch Initiativanträge möglich und können nur auf
-dem Endplenum abgestimmt werden.
+dem Endplenum frühestens am Folgetag nach Einreichung und Aushang abgestimmt werden.
 
 Wünsche nach einer Satzungsänderung sind bis spätestens sieben Tage vor dem
 Anfangsplenum geeignet (z.B. über die ZaPF-Mailingliste)
@@ -229,6 +229,11 @@ Auf der ZaPF muss dann zwingend ein Arbeitskreis zum Thema der vorgeschlagenen
 Satzungsänderungen durchgeführt werden, dessen Satzungsänderungsantrag bzw.
 Satzungsänderungsanträge bis spätestens 15:00 Uhr am Vortag des Endplenums bei
 der die ZaPF ausrichtenden Fachschaft eingereicht und ausgehängt werden müssen.
+
+Im Fall mehrtätiger Endplenen ändert sich die Frist so dass
+Satzungsänderungsanträge bis spätestens 15:00 Uhr am Tag vor dem letzten
+konsekutiven Endplenumstag ab Beginn des Endplenums bei der die ZaPF
+ausrichtenden Fachschaft eingereicht und ausgehängt werden müssen.
 
 # Schlussbestimmungen und Änderungshistorie {-}
 


### PR DESCRIPTION
In der jüngeren Vergangenheit sind ausrichtende Fachschaften dazu übergegangen mehrtätige Endplenen zu veranstalten. Die Abgabefrist für Satzungsänderungen fällt dabei im schlimsten Fall auf den ersten vollständigen Tag der ZaPF und erlaubt nur wenige Arbeitskreise stattfinden zu lassen.

Die Intention der Frist war Fachschaften ausreichende Zeit zu geben sich mit den Änderungsanträgen zu befassen. Dies ist auch gewährleistet, so lange sichergestellt wird, dass am letzten Plenumstag mit "etwa einem" Tag Vorlauf darüber abgestimmt wird.

Dies verkürzt die Zeit zur Meinungsbildung nicht, da die Anküdigungsfrist und die Pflicht einen Arbeitskreis zum Thema abzuhalten, unberührt bleibt.

Die Formulierung "letzter konsekutiver Endplenumstag ab Beginn des Endplenums" ziel darauf ab, dass während der Pandemie as Endplenum für Briefwahl unterbrochen wurde, so dass der letzte Endplenumstag Wochen nach Beginn des Endplenums war. In diesem Fall muss die Antragsfrist relativ zum Ende des ersten Endplenumsblock sein, z.B. sei die letzte Frist bei einem Endplenum fünftägigen Endplenum: Tag 1, Tag 2, Tag 3, Unterbrechung, Tag 4, Tag 5 um 15 Uhr an Tag 2, zur Abstimmung an Tag 3 und jeweils um 15 Uhr an Tag 1 und Tag 0 zur Abstimmung an Tag 2 und Tag 1 respektive.