### PR TITLE
Ändere Abschlussplenum zu Endplenum

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -37,7 +37,7 @@ Die ausrichtende Fachschaft legt den Programmablauf der Tagung fest und
 erarbeitet ein Protokoll der Veranstaltung, den sogenannten ZaPF-Reader.
 Sie stellt davon allen Mitgliedsfachschaften ein Exemplar zur Verfügung.
 
-Die Tagung beginnt mit dem Anfangsplenum und endet nach dem Abschlussplenum.
+Die Tagung beginnt mit dem Anfangsplenum und endet nach dem Endplenum.
 
 # Organe
 


### PR DESCRIPTION
Antrag:
Aktuell werden in Satzung und GO sowohl der Begriff "Abschlussplenum" wie auch der Begriff "Endplenum" verwendet. Da diese beide das Selbe bezeichnen, ist es aus unserer Sicht sinnvoll, diese Formen anzugleichen.

Im Arbeitskreis Geschäftsordnung sowie im Arbeitskreis Satzung wurde sich für die Harmonisierung auf "Endplenum" entschieden, dies ist auch die üblichere Formulierung (siehe dazu beispielsweise den Terminplan im Tagungsheft der ZaPF SommerZaPF 2026).