### PR TITLE
Ändere Verteilung des Readers

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -35,7 +35,7 @@ unmittelbar bestehen und deutlich erkennbar bleiben.
 
 Die ausrichtende Fachschaft legt den Programmablauf der Tagung fest und
 erarbeitet ein Protokoll der Veranstaltung, den sogenannten ZaPF-Reader.
-Sie stellt davon allen Mitgliedsfachschaften ein Exemplar zur Verfügung.
+Dieses wird allen Fachschaften, welche die ZaPF vertritt, zur Verfügung gestellt.
 
 Die Tagung beginnt mit dem Anfangsplenum und endet nach dem Abschlussplenum.
 


### PR DESCRIPTION
Antrag:
Diese Änderung passt gemeinsam mit einer Änderung der Geschäftsordnung für Plena der ZaPF, die Regularien zu den ZaPF-Readern an die aktuelle Praxis an, in der nicht mehr zwingend ein gedruckter ZaPF-Reader zur Verfügung gestellt wird.