### PR TITLE
Ändere vertretene Fachschaften

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -12,8 +12,9 @@ alle Menschen, welche diese Grundsätze teilen.
 
 # Mitglieder
 
-Die ZaPF setzt sich aus vertretenden Personen und Mitgliedern der Fachschaften
-Physik aller Hochschulen des deutschsprachigen Raumes zusammen.
+Die ZaPF setzt sich aus vertretenden Personen und Mitgliedern der Fachschaften,
+die Physik- bzw. physiknahe Studiengänge vertreten, aller Hochschulen des
+deutschsprachigen Raumes zusammen.
 
 Die Mitglieder verpflichten sich zur Einhaltung des Verhaltenskodex der ZaPF.
 


### PR DESCRIPTION
Antrag: 122

Antrag:
Die ZaPF wird in den letzten Jahren vermehrt von Fachschaften besucht, bei denen es sich nicht um Physikfachschaften im klassischen Sinne handelt. Diese Änderung trägt dem Rechnung, sodass sie physiknahe Studiengänge auch satzungsgemäß vertritt.